### PR TITLE
Use 'newSingleThreadExecutor()' to enforce a serialized work queue without the risk of reconfiguration.

### DIFF
--- a/client/src/main/java/redis/client/RedisClientBase.java
+++ b/client/src/main/java/redis/client/RedisClientBase.java
@@ -21,7 +21,7 @@ import redis.reply.Reply;
  */
 public class RedisClientBase {
   // Single threaded pipelining
-  private ExecutorService es = Executors.newFixedThreadPool(1);
+  private ExecutorService es = Executors.newSingleThreadExecutor();
   protected RedisProtocol redisProtocol;
 
   private AtomicInteger pipelined = new AtomicInteger(0);


### PR DESCRIPTION
To better enforce a serialized work queue it might be better to use `newSingleThreadExecutor()` so that the returned executor is guaranteed not to be reconfigurable to use additional threads.
